### PR TITLE
Throw an error instead of a warning if a child is killed by an unhand…

### DIFF
--- a/src/MultiProcessor.php
+++ b/src/MultiProcessor.php
@@ -428,7 +428,7 @@ class MultiProcessor {
         if(pcntl_wifsignaled($status)) {
             // Child terminated by signal, which wasn't handled.
             $signal = pcntl_wtermsig($status);
-            trigger_error('Child terminated by unhandled signal (' . $signal . ')', E_USER_WARNING);
+            trigger_error('Child terminated by unhandled signal (' . $signal . ')', E_USER_ERROR);
         }
         else if(pcntl_wifexited($status)) {
             // Clean exit, exit code returned by processor in exit() statement


### PR DESCRIPTION
…led signal. Otherwise jenkins for example, will think the process was successful while it in fact, was not. Example, server runs out of memory and kills a child